### PR TITLE
Add Dockerfile and initial backup setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git*
+Dockerfile
+.gitignore
+.travis.yml
+CONDUCT.md
+CONTRIBUTING.md
+LICENSE
+README.md
+shipit.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:2.3-alpine
+
+RUN apk add --no-cache \
+  postgresql-client \
+  postgresql-dev \
+  ca-certificates \
+  ruby-dev \
+  build-base \
+  bash \
+  linux-headers \
+  zlib-dev \
+  libxml2-dev \
+  libxslt-dev \
+  tzdata \
+  && rm -rf /var/cache/apk/*
+
+# Install the backup gem which is currently used to run backups.
+RUN gem install backup --no-doc
+
+# Copy the directories from the repo to the container.
+COPY . .
+
+# By default we'll just error out, given that we expect this container to be
+# run in the context of a Kubernetes cluster executing a different command.
+CMD ["echo", "FATAL: no command entrypoint provided in deployment YAML"]

--- a/config/postgresql.rb
+++ b/config/postgresql.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+##
+# Backup v4.x Configuration
+#
+# Documentation: http://meskyanichi.github.io/backup
+# Issue Tracker: https://github.com/meskyanichi/backup/issues
+
+require 'json'
+
+Backup::Model.new(:postgresql, 'PostgreSQL Backup') do
+
+  database PostgreSQL do |db|
+    db.name     = ENV.fetch('POSTGRESQL_DB')
+    db.username = ENV.fetch('POSTGRESQL_USER')
+    db.password = ENV.fetch('POSTGRESQL_PASSWORD')
+    db.host     = ENV.fetch('POSTGRESQL_HOST')
+    db.port     = 5432
+  end
+
+  compress_with Gzip
+
+  encrypt_with GPG do |encryption|
+    encryption.keys = {}
+    encryption.keys[ENV.fetch('GPG_EMAIL')] = ENV.fetch('GPG_PUBLIC_KEY')
+    encryption.recipients = ENV.fetch('GPG_EMAIL')
+  end
+
+  store_with S3 do |s3|
+    s3.access_key_id      = ENV.fetch('AWS_ACCESS_KEY')
+    s3.secret_access_key  = ENV.fetch('AWS_SECRET_KEY')
+    s3.bucket             = 'rubygems-backups'
+    s3.region             = 'us-west-2'
+    s3.path               = ENV.fetch('DEPLOYMENT_ENV')
+  end
+
+  notify_by Slack do |slack|
+    slack.on_success  = false
+    slack.on_warning  = true
+    slack.on_failure  = true
+    slack.webhook_url = ENV.fetch('SLACK_WEBHOOK_URL')
+  end
+
+end

--- a/config/public_postgresql.rb
+++ b/config/public_postgresql.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+##
+# Backup v4.x Configuration
+#
+# Documentation: http://meskyanichi.github.io/backup
+# Issue Tracker: https://github.com/meskyanichi/backup/issues
+
+require 'json'
+
+Backup::Model.new(:public_postgresql, 'RubyGems.org Public Database Dump') do
+
+  database PostgreSQL do |db|
+    db.name        = ENV.fetch('POSTGRESQL_DB')
+    db.username    = ENV.fetch('POSTGRESQL_USER')
+    db.password    = ENV.fetch('POSTGRESQL_PASSWORD')
+    db.host        = ENV.fetch('POSTGRESQL_HOST')
+    db.port        = 5432
+    db.only_tables = ['rubygems', 'versions', 'dependencies', 'linksets', 'version_histories', 'gem_downloads']
+  end
+
+  compress_with Gzip
+
+  store_with S3 do |s3|
+    s3.access_key_id      = ENV.fetch('AWS_ACCESS_KEY')
+    s3.secret_access_key  = ENV.fetch('AWS_SECRET_KEY')
+    s3.bucket             = 'rubygems-dumps'
+    s3.region             = 'us-west-2'
+    s3.path               = ENV.fetch('DEPLOYMENT_ENV')
+  end
+
+  notify_by Slack do |slack|
+    slack.on_success  = false
+    slack.on_warning  = true
+    slack.on_failure  = true
+    slack.webhook_url = ENV.fetch('SLACK_WEBHOOK_URL')
+  end
+
+end

--- a/script/backup_db.sh
+++ b/script/backup_db.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# Generates an encrypted backup of the RubyGems database and uploads it to S3.
+
+backup perform --trigger postgresql --config-file ../config/postgresql.rb

--- a/script/dump_db.sh
+++ b/script/dump_db.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# Generates a public dump of the RubyGems database and uploads it to S3.
+
+backup perform --trigger public_postgresql --config-file ../config/public_postgresql.rb


### PR DESCRIPTION
This PR is meant to reintroduce rubygems.org database backups after the old backup infrastructure went down in March (see https://github.com/rubygems/rubygems.org/issues/1977).

It includes the following:
- A basic `Dockerfile` based off of [the rubygems.org `Dockerfile`](https://github.com/rubygems/rubygems.org/blob/master/Dockerfile) as well as a `.dockerignore` file.
- A copy of the backup configuration files for both the private and public database backups. These were sourced from the old [rubygems-backups](https://github.com/rubygems/rubygems-infrastructure/tree/master/cookbooks/rubygems-backups) Chef configuration. The biggest difference is that instead of relying on ERB, which Chef would use to populate config variables, they now rely directly on environment variables which should be set in the Docker container by Kubernetes.
- A couple small scripts that are responsible for calling the [backup CLI](http://backup.github.io/backup/v4/) and specifying which configuration file to run, depending on if we're running a full database backup or a public database dump.

The biggest thing still missing from this PR is the Kubernetes configuration. I'm not sure if I should guess at the config and make inferences based off of the rubygems.org configs or if one of the maintainers working on the project would just like to do this, since there will need to be other infrastructure work done as well.

Please let me know what else I can do to help get this done and to get the public data dumps back online. Thanks!