### PR TITLE
Update ruby from 2.3 to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.7-alpine
 
 RUN apk add --no-cache \
   postgresql-client \


### PR DESCRIPTION
We also need to rebuild image to update pg_dump version. fixes:
```
[2022/01/03 00:45:15][error]   pg_dump: server version: 11.13; pg_dump
version: 10.8
[2022/01/03 00:45:15][error]   pg_dump: aborting because of server
version mismatch
[2022/01/03 00:45:15][error]   The following system errors were
returned:
[2022/01/03 00:45:15][error]   Errno::EPERM: Operation not permitted -
'pg_dump' returned exit code: 1
```