### PR TITLE
Update backup version to use beta release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ RUN apk add --no-cache \
   libxml2-dev \
   libxslt-dev \
   tzdata \
+  curl-dev \
   && rm -rf /var/cache/apk/*
 
 # Install the backup gem which is currently used to run backups.
-RUN gem install backup --no-doc
+RUN gem install backup --no-doc --version 5.0.0.beta3
 
 # Copy the directories from the repo to the container.
 COPY . .


### PR DESCRIPTION
curl-dev added to fix:
```
/ # gem install backup --no-doc --version 5.0.0.beta3
Building native extensions. This could take a while...
ERROR:  Error installing backup:
        ERROR: Failed to build gem native extension.

    current directory:
/usr/local/bundle/gems/ovirt-engine-sdk-4.4.1/ext/ovirtsdk4c
/usr/local/bin/ruby -I /usr/local/lib/ruby/2.7.0 -r
./siteconf20220104-47-1gma3z5.rb extconf.rb
checking for xml2-config... yes
checking for curl-config... no
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.
You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/local/bin/$(RUBY_BASE_NAME)
        --with-libcurl-config
        --without-libcurl-config
        --with-pkg-config
        --without-pkg-config
extconf.rb:40:in `<main>': The "libcurl" package isn't available.
(RuntimeError)

To see why this extension failed to compile, please check the mkmf.log
which can be found here:

  /usr/local/bundle/extensions/x86_64-linux-musl/2.7.0/ovirt-engine-sdk-4.4.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in
/usr/local/bundle/gems/ovirt-engine-sdk-4.4.1 for inspection.
Results logged to
/usr/local/bundle/extensions/x86_64-linux-musl/2.7.0/ovirt-engine-sdk-4.4.1/gem_make.out
```